### PR TITLE
fix : Mapper tool class (#91)

### DIFF
--- a/app/src/Factory/Utils/Mapper/Mapper.php
+++ b/app/src/Factory/Utils/Mapper/Mapper.php
@@ -41,17 +41,19 @@ abstract class Mapper
      * Map array associative to entity
      *
      * @param array<string, string|int> $obj
-     * @param class-string|string $entityName
+     * @param class-string|string|object $entity
      *
      * @return object|null
      */
     public static function mapArrayToEntity(
         array $obj,
-        string $entityName
+        string|object $entity
     ): ?object
     {
-        if (class_exists($entityName)) {
-            $entity = new $entityName();
+        if (class_exists(is_string($entity) ? $entity : $entity::class)) {
+            $entity = is_string($entity) ?
+                new $entity() :
+                $entity;
 
             if (!$entity instanceof AbstractEntity) {
                 return null;
@@ -64,7 +66,7 @@ abstract class Mapper
                         $key[0] = strtoupper($key[0]);
                         $method = "set".$key;
 
-                        if (method_exists($entity::class, $method)) {
+                        if (method_exists($entity, $method)) {
                             $entity->$method($value);
                         }
 

--- a/app/tests/Factory/Utils/Mapper/MapperTest.php
+++ b/app/tests/Factory/Utils/Mapper/MapperTest.php
@@ -87,6 +87,9 @@ class MapperTest extends TestCase
         $this->assertInstanceOf(DateTime::class, $entity->getUpdatedAt());
         $this->assertEquals($updatedAt, $entity->getUpdatedAt()->format(DATE_ATOM));
 
+        $postEntity = new Post();
+        $this->assertEquals($postEntity, Mapper::mapArrayToEntity($post, $postEntity));
+
         // Tests cases of null
         $entity = Mapper::mapArrayToEntity([], "App\\ClassNotExist::class");
         $this->assertNull($entity);


### PR DESCRIPTION
- The "mapArrayToEntity" function now allows for the option to pass either an Entity object or the name of the class as a parameter.