### PR TITLE
feat (#134) : Change status type of Entity User

### DIFF
--- a/app/scripts/DatabaseScript.php
+++ b/app/scripts/DatabaseScript.php
@@ -86,7 +86,7 @@ $pdo->query("
         `email` VARCHAR(255) NOT NULL UNIQUE,
         `createdAt` DATETIME NOT NULL,
         `role` VARCHAR(255) NOT NULL,
-        `status` BOOLEAN,
+        `status` INTEGER NOT NULL DEFAULT 0,
         `forgottenPasswordToken` VARCHAR(255),
         `expiredTokenAt` DATETIME,
         `emailValidateToken` VARCHAR(255),

--- a/app/src/Auth/Auth.php
+++ b/app/src/Auth/Auth.php
@@ -45,6 +45,7 @@ class Auth implements ContainerInterface
 {
 
     public static ?User $currentUser;
+    public static ?string $messageError;
     private Manager $manager;
     private Request $request;
     private SessionRepository $sessionRepository;
@@ -57,6 +58,7 @@ class Auth implements ContainerInterface
     public function __construct()
     {
         self::$currentUser = null;
+        self::$messageError = null;
 
         /**
          * @var Manager $manager
@@ -86,7 +88,7 @@ class Auth implements ContainerInterface
     {
         if ($credentials["email"] && $credentials["password"]) {
             /**
-             * @var User $user
+             * @var User|false $user
              */
             $user = (new UserRepository())
                 ->findByOne(
@@ -95,8 +97,8 @@ class Auth implements ContainerInterface
                 );
 
             if (
-                is_object($user) &&
-                $user->getStatus() &&
+                $user &&
+                $user->getStatus() === User::STATUS_CODE_REGISTERED &&
                 password_verify(
                     $credentials["password"],
                     $user->getPassword() ?? ""
@@ -104,6 +106,22 @@ class Auth implements ContainerInterface
             ) {
                 $this->isAuthenticateSuccessful($user);
                 return true;
+
+            }
+
+            if (
+                !$user ||
+                !password_verify(
+                    $credentials["password"],
+                    $user->getPassword() ?? ""
+                )
+            ) {
+                self::$messageError = "L'Email et/ou le mot de passe sont incorrects.";
+
+            }
+
+            if ($user && $user->getStatus() === User::STATUS_CODE_DEACTIVATED) {
+                self::$messageError = "Votre compte a été désactivé par un membre de notre équipe. N'hésitez pas à nous contacter via notre formulaire si vous souhaitez en savoir plus.";
 
             }
         }
@@ -206,7 +224,7 @@ class Auth implements ContainerInterface
                             classObject: User::class
                         );
 
-                    if ($user->getStatus()) {
+                    if ($user && $user->getStatus() === User::STATUS_CODE_REGISTERED) {
                         self::$currentUser = $user;
                     } else {
                         // Delete cookie session

--- a/app/src/Controller/AuthController.php
+++ b/app/src/Controller/AuthController.php
@@ -86,7 +86,7 @@ class AuthController extends AbstractController
 
             $form->setError(
                 "global",
-                "L'Email et/ou le mot de passe sont incorrects."
+                Auth::$messageError ?? ""
             );
         }
 
@@ -284,7 +284,7 @@ class AuthController extends AbstractController
 
             $user
                 ->setEmailValidateToken(null)
-                ->setStatus(true);
+                ->setStatus(User::STATUS_CODE_REGISTERED);
 
             $manager->flush($user);
 

--- a/app/src/Entity/User.php
+++ b/app/src/Entity/User.php
@@ -33,8 +33,10 @@ use Exception;
  */
 class User extends AbstractEntity
 {
-
     const TABLE_NAME = "user";
+    const STATUS_CODE_REGISTERED_WAITING = 0;
+    const STATUS_CODE_REGISTERED = 1;
+    const STATUS_CODE_DEACTIVATED = 2;
 
     private ?string $lastname = null;
     private ?string $firstname = null;
@@ -42,7 +44,7 @@ class User extends AbstractEntity
     private ?string $password = null;
     private ?string $email = null;
     private string $role = "ROLE_USER";
-    private ?bool $status = null;
+    private ?int $status = 0;
     private DateTime|string|null $createdAt = null;
     private ?string $emailValidateToken = null;
     private Datetime|string|null $expiredEmailTokenAt = null;
@@ -245,9 +247,9 @@ class User extends AbstractEntity
     /**
      * Get the status of the User
      *
-     * @return bool
+     * @return int
      */
-    public function getStatus(): bool
+    public function getStatus(): int
     {
         return $this->status;
 
@@ -257,11 +259,11 @@ class User extends AbstractEntity
     /**
      * Set the status of the User.
      *
-     * @param bool $status Status of the user
+     * @param int $status Status of the user
      *
      * @return self
      */
-    public function setStatus(bool $status): self
+    public function setStatus(int $status): self
     {
         $this->status = $status;
         return $this;

--- a/app/tests/Auth/AuthTest.php
+++ b/app/tests/Auth/AuthTest.php
@@ -85,7 +85,7 @@ class AuthTest extends TestCase
             ->setLastname("Test")
             ->setFirstname("Test")
             ->setPseudo("Test")
-            ->setStatus(true)
+            ->setStatus(User::STATUS_CODE_REGISTERED)
             ->setPassword(password_hash("password", PASSWORD_ARGON2ID))
             ->setEmail("test@test.com");
         $this->manager->flush($this->user);

--- a/app/tests/Controller/ProfileControllerTest.php
+++ b/app/tests/Controller/ProfileControllerTest.php
@@ -98,7 +98,7 @@ class ProfileControllerTest extends TestCase
             ->setLastname("Test")
             ->setFirstname("Test")
             ->setPseudo("Test")
-            ->setStatus(true)
+            ->setStatus(User::STATUS_CODE_REGISTERED)
             ->setPassword(password_hash("password", PASSWORD_ARGON2ID))
             ->setEmail("test@test.fr");
         $this->manager->flush($this->user);

--- a/app/tests/Entity/EntityTest.php
+++ b/app/tests/Entity/EntityTest.php
@@ -92,7 +92,7 @@ class EntityTest extends TestCase
         $this->assertEquals("Pseudo", $user->getPseudo());
         $this->assertEquals("mail@test.fr", $user->getEmail());
         $this->assertEquals("ROLE_USER", $user->getRole());
-        $this->assertEquals(false, $user->getStatus());
+        $this->assertEquals(User::STATUS_CODE_REGISTERED_WAITING, $user->getStatus());
         $this->assertEquals("Token", $user->getEmailValidateToken());
         $this->assertEquals("Token", $user->getForgottenPasswordToken());
         $this->assertEquals(new DateTime($createdAt->format(DATE_ATOM)), $user->getCreatedAt());

--- a/app/tests/KernelTest.php
+++ b/app/tests/KernelTest.php
@@ -153,7 +153,7 @@ class KernelTest extends TestCase
             ->setLastname("Test")
             ->setPseudo("Test")
             ->setEmail("test@test.com")
-            ->setStatus(true)
+            ->setStatus(User::STATUS_CODE_REGISTERED)
             ->setPassword(password_hash("password", PASSWORD_ARGON2ID));
 
         $manager->flush($user);

--- a/app/tests/Repository/UserRepositoryTest.php
+++ b/app/tests/Repository/UserRepositoryTest.php
@@ -204,7 +204,7 @@ class UserRepositoryTest extends TestCase
         $statement->bindValue(":createdAt", $user->getCreatedAt()->format(DATE_ATOM));
         $statement->bindValue(":expiredTokenAt", $user->getExpiredTokenAt()->format(DATE_ATOM));
         $statement->bindValue(":role", $user->getRole());
-        $statement->bindValue(":status", $user->getStatus() ? 1 : 0);
+        $statement->bindValue(":status", $user->getStatus());
         $statement->execute();
     }
 


### PR DESCRIPTION
- DB script : update column status type to integer in DB ;
- Entity User : update status type to integer and add constants ;
- Auth : Replace check bool to check status code integer, add the static variable of error message for each case ;
- AuthController : Take static message error ;
- Fix : All tests who used status account user.